### PR TITLE
ci(github): add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Keep GitHub Actions and Python dependencies patched automatically

## Changes
- Add `.github/dependabot.yml` with weekly updates for `github-actions` and `pip`

## Related Issue
Closes #4

## Notes
-

## Test
- [ ] Dependabot lists the repo in Insights and runs on schedule
