### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Report privately via [GitHub's security advisory form](https://github.com/somnio-kimm/energy_consumption_analysis/security/advisories/new),
+or email the maintainers directly.
+
+You can expect an initial response within 5 business days.
+
+## Supported Versions
+
+Only the latest release on the default branch receives security fixes.


### PR DESCRIPTION
## Summary
- Provide a private security disclosure path

## Changes
- Add `SECURITY.md` pointing at GitHub's private advisory form for this repo

## Related Issue
Closes #13

## Notes
- Issue template already points here for security reports

## Test
- [ ] Link resolves
