### PR TITLE
chore(repo): add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.venv
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.ipynb_checkpoints
+__pycache__
+docs


### PR DESCRIPTION
## Summary
- Exclude caches, docs, and VCS data from future Docker builds

## Changes
- Add `.dockerignore`

## Related Issue
Closes #16

## Notes
-

## Test
- [ ] Docker build context excludes `.git`, `docs/`, cache dirs
