### PR TITLE
chore(tooling): add root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: install lint format pre-commit jupyter clean
+
+install:
+	uv sync --all-extras --dev
+	uv run pre-commit install
+
+lint:
+	uv run ruff check .
+
+format:
+	uv run ruff format .
+	uv run ruff check --fix .
+
+pre-commit:
+	uv run pre-commit run --all-files
+
+jupyter:
+	uv run jupyter lab
+
+clean:
+	rm -rf .pytest_cache .ruff_cache .mypy_cache build dist *.egg-info
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type d -name .ipynb_checkpoints -exec rm -rf {} +


### PR DESCRIPTION
## Summary
- Single entrypoint for dev tasks

## Changes
- Add root `Makefile` with `install`, `lint`, `format`, `pre-commit`, `jupyter`, `clean`

## Related Issue
Closes #17

## Notes
- Targets depend on pyproject.toml landing

## Test
- [ ] Each target runs from repo root
