### PR TITLE
chore(tooling): add .pre-commit-config.yaml with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+exclude: third_party/
+
+repos:
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.11.7
+    hooks:
+      - id: uv-lock
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.8.6
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format


### PR DESCRIPTION
## Summary
- Wire pre-commit with ruff check + format and uv-lock

## Changes
- Add `.pre-commit-config.yaml` with pinned ruff hooks and uv-lock hook

## Related Issue
Closes #18

## Notes
- Installed by `make install`, executed by `make pre-commit`

## Test
- [ ] `make pre-commit` passes on a clean tree once pyproject is in place
